### PR TITLE
Build coffeescript files before publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .#*
 
 .DS_Store
+/build

--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-require('coffee-script/register')
-module.exports = require('./lib')
+module.exports = require('./build')

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "homepage": "https://github.com/resin-io-playground/metalsmith-dynamic",
   "dependencies": {
-    "coffee-script": "^1.10.0",
     "lodash": "^4.12.0"
+  },
+  "devDependencies": {
+    "coffeescript": "^1.12.7"
   }
 }


### PR DESCRIPTION
This avoids the needs to compile on every run

Change-type: patch